### PR TITLE
update module name to match repository name

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/knq/sdhook"
+	"github.com/kenshaw/sdhook"
 	"github.com/sirupsen/logrus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,7 @@ require (
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/google/go-cmp v0.3.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
-	github.com/knq/jwt v0.0.0-20180925223530-fc44a4704737
-	github.com/knq/pemutil v0.0.0-20181215144041-fb6fad722528 // indirect
+	github.com/kenshaw/jwt v0.2.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/philhofer/fwd v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/knq/sdhook
+module github.com/kenshaw/sdhook
 
 require (
 	cloud.google.com/go v0.38.0

--- a/opts.go
+++ b/opts.go
@@ -11,7 +11,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/fluent/fluent-logger-golang/fluent"
-	"github.com/knq/jwt/gserviceaccount"
+	"github.com/kenshaw/jwt/gserviceaccount"
 
 	"github.com/sirupsen/logrus"
 


### PR DESCRIPTION
Hi there,
i think the repository name changes and therefore the go.mod needs an update.

```
$ go get github.com/kenshaw/sdhook
go: github.com/kenshaw/sdhook upgrade => v0.0.0-20190801142816-0b7fa827d09a
go get: github.com/kenshaw/sdhook@v0.0.0-20190801142816-0b7fa827d09a: parsing go.mod:
        module declares its path as: github.com/knq/sdhook
                but was required as: github.com/kenshaw/sdhook
```

Regards,
eqionx76